### PR TITLE
FindObjects method overload

### DIFF
--- a/Auios.QuadTree/QuadTree.cs
+++ b/Auios.QuadTree/QuadTree.cs
@@ -248,5 +248,9 @@ namespace Auios.QuadTree
 
             return result.ToArray();
         }
+        public T[] FindObjects(T bounds)
+        {
+            return FindObjects(new QuadTreeRect(_objectBounds.GetLeft(bounds), _objectBounds.GetTop(bounds), _objectBounds.GetRight(bounds), _objectBounds.GetBottom(bounds)));
+        }
     }
 }


### PR DESCRIPTION
First off, thanks for writing this QuadTree implementation.

I'm opening this PR because I found it unusual to need to create a special QuadTreeRect object to define the region I wish to query.

It seemed to me that IQuadTreeObjectBounds<T> already defined a way to get an area for any T

I could have added this as a simple extension method in my own code, but I feel like this method could happily live in this class too.